### PR TITLE
Update EclipseMC tag and addresses

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -108,7 +108,11 @@
             "name" : "OzCoin",
             "link" : "http://ozcoin.net/"
         },
-        "EMC" : {
+        "EMC:" : {
+            "name" : "EclipseMC",
+            "link" : "https://eclipsemc.com/"
+        },
+        "EMC " : {
             "name" : "EclipseMC",
             "link" : "https://eclipsemc.com/"
         },
@@ -659,6 +663,10 @@
             "link" : "http://bitminter.com/"
         },
         "15xiShqUqerfjFdyfgBH1K7Gwp6cbYmsTW" : {
+            "name" : "EclipseMC",
+            "link" : "https://eclipsemc.com/"
+        },
+        "18M9o2mXNjNR96yKe7eyY6pfP6Nx4Nso3d" : {
             "name" : "EclipseMC",
             "link" : "https://eclipsemc.com/"
         },


### PR DESCRIPTION
Fixes https://github.com/mempool/mining-pools/issues/5
Note that automatic block deletion is not yet implemented in https://github.com/mempool/mempool.

Run the following query on prod and restart the nodejs backend to re-index wrong blocks:

```mysql
delete blocks from blocks join pools on pools.id = blocks.pool_id where pools.slug = 'eclipsemc';
delete blocks from blocks join pools on pools.id = blocks.pool_id where pools.slug = 'unknown';
truncate hashrates;
```

I'll work on automatic re-indexing when pools are updated, so RPIs can get the correct data as well. Or, we could deliver this as a database migration at the next update.

Looks like it also picked up more blocks that were previously tagged to `unknown`

```mysql
select min(height) as "First block", max(height) as "Last block", count(*) as "Block count" from blocks join pools on pools.id = blocks.pool_id where pools.slug = 'eclipsemc';
```

First block | Last block | Block count
-- | -- | --
166138 | 400824 | 5898

