### PR TITLE
add new btc.com coinbase tag

### DIFF
--- a/pools.json
+++ b/pools.json
@@ -32,7 +32,7 @@
             "name" : "BTC.com",
             "link" : "https://pool.btc.com"
         },
-        "/btccom/" : {
+        "btccom" : {
             "name" : "BTC.com",
             "link" : "https://pool.btc.com"
         },

--- a/pools.json
+++ b/pools.json
@@ -32,6 +32,10 @@
             "name" : "BTC.com",
             "link" : "https://pool.btc.com"
         },
+        "/btccom/" : {
+            "name" : "BTC.com",
+            "link" : "https://pool.btc.com"
+        },
         "BITFARMS": {
             "name": "Bitfarms",
             "link": "https://www.bitfarms.io/"


### PR DESCRIPTION
added "btccom" tag to "coinbase_tags".

btc.com appears to have changed their coinbase tag syntax starting at block 746530. tested and confirmed on btc.com explorer (https://explorer.btc.com/btc/block/746530)