### PR TITLE
[4] Add new tag for emcd

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1,0 +1,1521 @@
+[
+  {
+    "id": 1,
+    "name": "Bitcoin Affiliate Network",
+    "addresses": [],
+    "tags": [
+      "bitcoinaffiliatenetwork.com"
+    ],
+    "link": "https://mining.bitcoinaffiliatenetwork.com"
+  },
+  {
+    "id": 2,
+    "name": "8baochi",
+    "addresses": [
+      "1Hk9gD8xMo2XBUhE73y5zXEM8xqgffTB5f"
+    ],
+    "tags": [
+      "/八宝池 8baochi.com/"
+    ],
+    "link": "https://8baochi.com"
+  },
+  {
+    "id": 3,
+    "name": "EMCDPool",
+    "addresses": [
+      "1BDbsWi3Mrcjp1wdop3PWFNCNZtu4R7Hjy"
+    ],
+    "tags": [
+      "/EMCD/",
+      "/one_more_mcd/",
+      "get___emcd"
+    ],
+    "link": "https://pool.emcd.io"
+  },
+  {
+    "id": 4,
+    "name": "Luxor",
+    "addresses": [
+      "1MkCDCzHpBsYQivp8MxjY5AkTGG1f2baoe"
+    ],
+    "tags": [
+      "/LUXOR/"
+    ],
+    "link": "https://mining.luxor.tech"
+  },
+  {
+    "id": 5,
+    "name": "OKMINER",
+    "addresses": [
+      "15xcAZ2HfaSwYbCV6GGbasBSAekBRRC5Q2"
+    ],
+    "tags": [
+      "okminer.com/euz"
+    ],
+    "link": "https://okminer.com"
+  },
+  {
+    "id": 6,
+    "name": "Bitcoin.com",
+    "addresses": [],
+    "tags": [
+      "pool.bitcoin.com"
+    ],
+    "link": "https://www.bitcoin.com"
+  },
+  {
+    "id": 7,
+    "name": "BytePool",
+    "addresses": [
+      "39m5Wvn9ZqyhYmCYpsyHuGMt5YYw4Vmh1Z"
+    ],
+    "tags": [
+      "/bytepool.com/"
+    ],
+    "link": "https://www.bytepool.com"
+  },
+  {
+    "id": 8,
+    "name": "Minerium",
+    "addresses": [],
+    "tags": [
+      "/Minerium.com/"
+    ],
+    "link": "https://www.minerium.com"
+  },
+  {
+    "id": 9,
+    "name": "CANOE",
+    "addresses": [
+      "1Afcpc2FpPnREU6i52K3cicmHdvYRAH9Wo"
+    ],
+    "tags": [],
+    "link": "https://www.canoepool.com"
+  },
+  {
+    "id": 10,
+    "name": "TripleMining",
+    "addresses": [],
+    "tags": [
+      "Triplemining.com",
+      "triplemining"
+    ],
+    "link": "https://www.triplemining.com"
+  },
+  {
+    "id": 11,
+    "name": "NovaBlock",
+    "addresses": [
+      "3Bmb9Jig8A5kHdDSxvDZ6eryj3AXd3swuJ"
+    ],
+    "tags": [
+      "/NovaBlock/"
+    ],
+    "link": "https://novablock.com"
+  },
+  {
+    "id": 12,
+    "name": "PHash.IO",
+    "addresses": [],
+    "tags": [
+      "/phash.cn/",
+      "/phash.io/"
+    ],
+    "link": "https://phash.io"
+  },
+  {
+    "id": 13,
+    "name": "Carbon Negative (unidentified)",
+    "addresses": [
+      "33SAB6pzbhEGPbfY6NVgRDV7jVfspZ3A3Z"
+    ],
+    "tags": [],
+    "link": "https://github.com/0xB10C/known-mining-pools/issues/48"
+  },
+  {
+    "id": 14,
+    "name": "UKRPool",
+    "addresses": [
+      "125K2xfiBdae42gSKiCGwi85Frpy1vHmGj"
+    ],
+    "tags": [
+      "Ukrpool.com"
+    ],
+    "link": "https://ukrpool.com"
+  },
+  {
+    "id": 15,
+    "name": "simplecoin.us",
+    "addresses": [],
+    "tags": [
+      "simplecoin"
+    ],
+    "link": "https://simplecoin.us"
+  },
+  {
+    "id": 16,
+    "name": "Give Me Coins",
+    "addresses": [],
+    "tags": [
+      "Give-Me-Coins"
+    ],
+    "link": "https://give-me-coins.com"
+  },
+  {
+    "id": 17,
+    "name": "Helix",
+    "addresses": [],
+    "tags": [
+      "/Helix/"
+    ],
+    "link": ""
+  },
+  {
+    "id": 18,
+    "name": "TogetherPool",
+    "addresses": [
+      "bc1qwlrsvgtn99rqp3fgaxq6f6jkgms80rnej0a8tc"
+    ],
+    "tags": [
+      "TogetherPool"
+    ],
+    "link": "https://www.togetherpool.com"
+  },
+  {
+    "id": 19,
+    "name": "Cointerra",
+    "addresses": [
+      "1BX5YoLwvqzvVwSrdD4dC32vbouHQn2tuF"
+    ],
+    "tags": [
+      "cointerra"
+    ],
+    "link": "https://cointerra.com"
+  },
+  {
+    "id": 20,
+    "name": "OzCoin",
+    "addresses": [],
+    "tags": [
+      "ozco.in",
+      "ozcoin"
+    ],
+    "link": "https://ozcoin.net"
+  },
+  {
+    "id": 21,
+    "name": "EkanemBTC",
+    "addresses": [
+      "1Cs5RT9SRk1hxsdzivAfkjesNmVVJqfqkw"
+    ],
+    "tags": [],
+    "link": "https://ekanembtc.com"
+  },
+  {
+    "id": 22,
+    "name": "F2Pool",
+    "addresses": [
+      "1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY",
+      "bc1q7wedv4zdu5smt3shljpu5mgns48jn299mukymc",
+      "bc1qf274x7penhcd8hsv3jcmwa5xxzjl2a6pa9pxwm"
+    ],
+    "tags": [
+      "七彩神仙鱼",
+      "🐟"
+    ],
+    "link": "https://www.f2pool.com"
+  },
+  {
+    "id": 23,
+    "name": "ST Mining Corp",
+    "addresses": [],
+    "tags": [
+      "st mining corp"
+    ],
+    "link": "https://bitcointalk.org/index.php?topic=77000.msg3207708#msg3207708"
+  },
+  {
+    "id": 24,
+    "name": "Bitdeer",
+    "addresses": [],
+    "tags": [
+      "Bitdeer"
+    ],
+    "link": "https://www.bitdeer.com"
+  },
+  {
+    "id": 25,
+    "name": "OKKONG",
+    "addresses": [
+      "16JHXJ7M2MubWNX9grnqbjUqJ5PHwcCWw2"
+    ],
+    "tags": [
+      "/hash.okkong.com/"
+    ],
+    "link": "https://hash.okkong.com"
+  },
+  {
+    "id": 26,
+    "name": "GHash.IO",
+    "addresses": [
+      "1CjPR7Z5ZSyWk6WtXvSFgkptmpoi4UM9BC"
+    ],
+    "tags": [
+      "ghash.io"
+    ],
+    "link": "https://ghash.io"
+  },
+  {
+    "id": 27,
+    "name": "RigPool",
+    "addresses": [
+      "1JpKmtspBJQVXK67DJP64eBJcAPhDvJ9Er"
+    ],
+    "tags": [
+      "/RigPool.com/"
+    ],
+    "link": "https://www.rigpool.com"
+  },
+  {
+    "id": 28,
+    "name": "NMCbit",
+    "addresses": [],
+    "tags": [
+      "nmcbit.com"
+    ],
+    "link": "https://nmcbit.com"
+  },
+  {
+    "id": 29,
+    "name": "MultiCoin.co",
+    "addresses": [],
+    "tags": [
+      "Mined by MultiCoin.co"
+    ],
+    "link": "https://multicoin.co"
+  },
+  {
+    "id": 30,
+    "name": "Patels",
+    "addresses": [
+      "197miJmttpCt2ubVs6DDtGBYFDroxHmvVB",
+      "19RE4mz2UbDxDVougc6GGdoT4x5yXxwFq2"
+    ],
+    "tags": [],
+    "link": "https://patelsminingpool.com"
+  },
+  {
+    "id": 31,
+    "name": "SpiderPool",
+    "addresses": [
+      "125m2H43pwKpSZjLhMQHneuTwTJN5qRyYu",
+      "38u1srayb1oybVB43UWKBJsrwJbdHGtPx2"
+    ],
+    "tags": [
+      "/SpiderPool/"
+    ],
+    "link": "https://www.spiderpool.com"
+  },
+  {
+    "id": 32,
+    "name": "OKExPool",
+    "addresses": [],
+    "tags": [
+      "/www.okex.com/"
+    ],
+    "link": "https://www.okex.com"
+  },
+  {
+    "id": 33,
+    "name": "Eligius",
+    "addresses": [],
+    "tags": [
+      "Eligius"
+    ],
+    "link": "https://eligius.st"
+  },
+  {
+    "id": 34,
+    "name": "175btc",
+    "addresses": [],
+    "tags": [
+      "Mined By 175btc.com"
+    ],
+    "link": "https://www.175btc.com"
+  },
+  {
+    "id": 35,
+    "name": "Bravo Mining",
+    "addresses": [],
+    "tags": [
+      "/bravo-mining/"
+    ],
+    "link": "https://www.bravo-mining.com"
+  },
+  {
+    "id": 36,
+    "name": "DCEX",
+    "addresses": [],
+    "tags": [
+      "/DCEX/"
+    ],
+    "link": "https://dcexploration.cn"
+  },
+  {
+    "id": 37,
+    "name": "Bitcoin-Ukraine",
+    "addresses": [],
+    "tags": [
+      "/Bitcoin-Ukraine.com.ua/"
+    ],
+    "link": "https://bitcoin-ukraine.com.ua"
+  },
+  {
+    "id": 38,
+    "name": "HashBX",
+    "addresses": [],
+    "tags": [
+      "/Mined by HashBX.io/"
+    ],
+    "link": "https://hashbx.io"
+  },
+  {
+    "id": 39,
+    "name": "MegaBigPower",
+    "addresses": [
+      "17JJ3oZyF4ShQMGukDjpMWhmooCjEvoVVB",
+      "18xf3MQvdVzKhyRvog8Q5P5THWvSjJUkzf",
+      "1K7znxRfkS8R1hcmyMvHDum1hAQreS4VQ4",
+      "1KTNEBhQdj81UhDkJaoe3r8VtAsrnmpmnS"
+    ],
+    "tags": [
+      "megabigpower.com"
+    ],
+    "link": "https://megabigpower.com"
+  },
+  {
+    "id": 40,
+    "name": "Tricky's BTC Pool",
+    "addresses": [
+      "1AePMyovoijxvHuKhTqWvpaAkRCF4QswC6"
+    ],
+    "tags": [],
+    "link": "https://pool.wemine.uk"
+  },
+  {
+    "id": 41,
+    "name": "BATPOOL",
+    "addresses": [
+      "167ApWWxUSFQmz2jdz9xop3oAKdLejvMML"
+    ],
+    "tags": [
+      "/BATPOOL/"
+    ],
+    "link": "https://www.batpool.com"
+  },
+  {
+    "id": 42,
+    "name": "Yourbtc.net",
+    "addresses": [],
+    "tags": [
+      "yourbtc.net"
+    ],
+    "link": "https://yourbtc.net"
+  },
+  {
+    "id": 43,
+    "name": "BTC.com",
+    "addresses": [
+      "1Bf9sZvBHPFGVPX71WX2njhd1NXKv5y7v5",
+      "34qkc2iac6RsyxZVfyE2S5U5WcRsbg2dpK",
+      "36cWgjEtxQSFgbHTJDw5AB96ZX7fJk1URd",
+      "3EhLZarJUNSfV6TWMZY1Nh5mi3FMsdHa5U",
+      "3NA8hsjfdgVkmmVS9moHmkZsVCoLxUkvvv",
+      "bc1qjl8uwezzlech723lpnyuza0h2cdkvxvh54v3dn"
+    ],
+    "tags": [
+      "/BTC.COM/",
+      "/BTC.com/",
+      "btccom"
+    ],
+    "link": "https://pool.btc.com"
+  },
+  {
+    "id": 44,
+    "name": "transactioncoinmining",
+    "addresses": [
+      "1qtKetXKgqa7j1KrB19HbvfRiNUncmakk"
+    ],
+    "tags": [],
+    "link": "https://sha256.transactioncoinmining.com"
+  },
+  {
+    "id": 45,
+    "name": "BitClub",
+    "addresses": [
+      "155fzsEBHy9Ri2bMQ8uuuR3tv1YzcDywd4"
+    ],
+    "tags": [
+      "/BitClub Network/"
+    ],
+    "link": "https://bitclubpool.com"
+  },
+  {
+    "id": 46,
+    "name": "myBTCcoin Pool",
+    "addresses": [
+      "151T7r1MhizzJV6dskzzUkUdr7V8JxV2Dx"
+    ],
+    "tags": [
+      "myBTCcoin Pool"
+    ],
+    "link": "https://mybtccoin.com"
+  },
+  {
+    "id": 47,
+    "name": "BTC Guild",
+    "addresses": [],
+    "tags": [
+      "BTC Guild"
+    ],
+    "link": "https://www.btcguild.com"
+  },
+  {
+    "id": 48,
+    "name": "Sigmapool.com",
+    "addresses": [
+      "12cKiMNhCtBhZRUBCnYXo8A4WQzMUtYjmR"
+    ],
+    "tags": [
+      "/Sigmapool.com/"
+    ],
+    "link": "https://sigmapool.com"
+  },
+  {
+    "id": 49,
+    "name": "BTC.TOP",
+    "addresses": [
+      "1Hz96kJKF2HLPGY15JWLB5m9qGNxvt8tHJ"
+    ],
+    "tags": [
+      "/BTC.TOP/"
+    ],
+    "link": "https://btc.top"
+  },
+  {
+    "id": 50,
+    "name": "Waterhole",
+    "addresses": [
+      "1FLH1SoLv4U68yUERhDiWzrJn5TggMqkaZ"
+    ],
+    "tags": [
+      "/WATERHOLE.IO/"
+    ],
+    "link": "https://btc.waterhole.io"
+  },
+  {
+    "id": 51,
+    "name": "DPOOL",
+    "addresses": [
+      "1ACAgPuFFidYzPMXbiKptSrwT74Dg8hq2v",
+      "1AM2fYfpY3ZeMeCKXmN66haoWxvB89pJUx"
+    ],
+    "tags": [
+      "/DPOOL.TOP/"
+    ],
+    "link": "https://www.dpool.top"
+  },
+  {
+    "id": 52,
+    "name": "shawnp0wers",
+    "addresses": [
+      "12znnESiJ3bgCLftwwrg9wzQKN8fJtoBDa",
+      "18HEMWFXM9UGPVZHUMdBPD3CMFWYn2NPRX"
+    ],
+    "tags": [
+      "--Nug--"
+    ],
+    "link": "https://www.brainofshawn.com"
+  },
+  {
+    "id": 53,
+    "name": "SecretSuperstar",
+    "addresses": [],
+    "tags": [
+      "/SecretSuperstar/"
+    ],
+    "link": ""
+  },
+  {
+    "id": 54,
+    "name": "BitFury",
+    "addresses": [
+      "14yfxkcpHnju97pecpM7fjuTkVdtbkcfE6",
+      "1AcAj9p6zJn4xLXdvmdiuPCtY7YkBPTAJo",
+      "1FeDtFhARLxjKUPPkQqEBL78tisenc9znS",
+      "1Nd99aNgYWpKkqcqSMgWtdtVDadewAS5F7"
+    ],
+    "tags": [
+      "/BitFury/",
+      "/Bitfury/"
+    ],
+    "link": "https://bitfury.com"
+  },
+  {
+    "id": 55,
+    "name": "TATMAS Pool",
+    "addresses": [],
+    "tags": [
+      "/ViaBTC/TATMAS Pool/"
+    ],
+    "link": "https://tmsminer.com"
+  },
+  {
+    "id": 56,
+    "name": "mmpool",
+    "addresses": [],
+    "tags": [
+      "mmpool"
+    ],
+    "link": "https://mmpool.org/pool"
+  },
+  {
+    "id": 57,
+    "name": "Polmine",
+    "addresses": [
+      "13vWXwzNF5Ef9SUXNTdr7de7MqiV4G1gnL",
+      "16cv7wyeG6RRqhvJpY21CnsjxuKj2gAoK2",
+      "16jnC5hVyjk4gE6BJtLqkkyfZHqXCB5PBu",
+      "17kkmDx8eSwj2JTTULb3HkJhCmexfysExz",
+      "1AajKXkaq2DsnDmP8ZPTrE5gH1HFo1x3AU",
+      "1JrYhdhP2jCY6JwuVzdk9jUwc4pctcSes7",
+      "1Nsvmnv8VcTMD643xMYAo35Aco3XA5YPpe"
+    ],
+    "tags": [
+      "by polmine.pl",
+      "bypmneU"
+    ],
+    "link": "https://polmine.pl"
+  },
+  {
+    "id": 58,
+    "name": "HASHPOOL",
+    "addresses": [],
+    "tags": [
+      "HASHPOOL"
+    ],
+    "link": "https://hashpool.com"
+  },
+  {
+    "id": 59,
+    "name": "Multipool",
+    "addresses": [
+      "1MeffGLauEj2CZ18hRQqUauTXb9JAuLbGw"
+    ],
+    "tags": [],
+    "link": "https://www.multipool.us"
+  },
+  {
+    "id": 60,
+    "name": "Tangpool",
+    "addresses": [
+      "12Taz8FFXQ3E2AGn3ZW1SZM5bLnYGX4xR6"
+    ],
+    "tags": [
+      "/Tangpool/"
+    ],
+    "link": "https://www.tangpool.com"
+  },
+  {
+    "id": 61,
+    "name": "AntPool",
+    "addresses": [
+      "12dRugNcdxK39288NjcDV4GX7rMsKCGn6B",
+      "15kiNKfDWsq7UsPg87UwxA8rVvWAjzRkYS",
+      "16MdTdqmXusauybtXTmFEW4GNFPPgGxQYE",
+      "16kUc5B48qnASbxeZTisCqTNx6G3DPXuKn",
+      "17gVZssumiJqYMCHozHKXGyaAvyu6NCX6V",
+      "1AJQ3jXhUF8WiisEcuVd8Xmfq4QJ7n1SdL",
+      "1BWW3pg5jb6rxebrNeo9TATarwJ1rthnoe",
+      "1CyB8GJNEsNVXtPutB36nrDY3fMXBTzXSX",
+      "1D4UZG4qo8bF1MuZHSEyBHRZaxT8inatXS",
+      "1DDXyKUT6q3H9e5QXm2Gv6BNNWgztFG55g",
+      "1Dek9ArRHb9tyWb9gaaX8SWmkfi5V7U5Y6",
+      "1DyR7HPQWjM6Zrnk7SzHVY2GEpXRGNNH9o",
+      "1FdJkPdpXtK3t5utZHJAop3saLZWfPfgak",
+      "1GRcX882sdBYCAWyG99iF2oz7j3nYzXhLM",
+      "1Gp7iCzDGMZiV55Kt8uKsux6VyoHe1aJaN",
+      "1H3u6R813MHGYhmGW6v86EYYriawRtACYD",
+      "1JBVrhSSDrZrRmm4RnoWouqgGGqJMvWHi8",
+      "1JwUDWVSbAY5NeCBJhxQk1E8AfETfZuPj4",
+      "1K8PNogxBZ6ts532DZnzxdbjgzJLjLdXqz",
+      "1LTGvTjDxiy5S9YcKEE9Lb7xSpZcPSqinw",
+      "1NS4gbx1G2D5rc9PnvVsPys12nKxGiQg72",
+      "1Nh7uHdvY6fNwtQtM1G5EZAFPLC33B59rB",
+      "1Sjj2cPC3rTWcSTEYDeu2f3BavLosog4T",
+      "1jLVpwtNMfXWaHY4eiLDmGuBxokYLgv1X"
+    ],
+    "tags": [
+      "/AntPool/",
+      "Mined by AntPool"
+    ],
+    "link": "https://www.antpool.com"
+  },
+  {
+    "id": 62,
+    "name": "1Hash",
+    "addresses": [
+      "1F1xcRt8H8Wa623KqmkEontwAAVqDSAWCV"
+    ],
+    "tags": [
+      "Mined by 1hash.com"
+    ],
+    "link": "https://www.1hash.com"
+  },
+  {
+    "id": 63,
+    "name": "BTCDig",
+    "addresses": [
+      "15MxzsutVroEE9XiDckLxUHTCDAEZgPZJi"
+    ],
+    "tags": [],
+    "link": "https://btcdig.com"
+  },
+  {
+    "id": 64,
+    "name": "DCExploration",
+    "addresses": [],
+    "tags": [
+      "/DCExploration/"
+    ],
+    "link": "https://dcexploration.cn"
+  },
+  {
+    "id": 65,
+    "name": "BTC Nuggets",
+    "addresses": [
+      "1BwZeHJo7b7M2op7VDfYnsmcpXsUYEcVHm"
+    ],
+    "tags": [],
+    "link": "https://104.197.8.250"
+  },
+  {
+    "id": 66,
+    "name": "Solo CK",
+    "addresses": [],
+    "tags": [
+      "/solo.ckpool.org/"
+    ],
+    "link": "https://solo.ckpool.org"
+  },
+  {
+    "id": 68,
+    "name": "Nexious",
+    "addresses": [
+      "1GBo1f2tzVx5jScV9kJXPUP9RjvYXuNzV7"
+    ],
+    "tags": [
+      "/Nexious/"
+    ],
+    "link": "https://nexious.com"
+  },
+  {
+    "id": 69,
+    "name": "ArkPool",
+    "addresses": [
+      "1QEiAhdHdMhBgVbDM7zUXWGkNhgEEJ6uLd"
+    ],
+    "tags": [
+      "/ArkPool/"
+    ],
+    "link": ""
+  },
+  {
+    "id": 70,
+    "name": "1THash",
+    "addresses": [
+      "147SwRQdpCfj5p8PnfsXV2SsVVpVcz3aPq",
+      "15vgygQ7ZsWdvZpctmTZK4673QBHsos6Sh"
+    ],
+    "tags": [
+      "/1THash&58COIN/",
+      "/1THash/"
+    ],
+    "link": "https://www.1thash.top"
+  },
+  {
+    "id": 71,
+    "name": "KuCoin Pool",
+    "addresses": [
+      "1ArTPjj6pV3aNRhLPjJVPYoxB98VLBzUmb"
+    ],
+    "tags": [
+      "KuCoinPool"
+    ],
+    "link": "https://www.kucoin.com/mining-pool"
+  },
+  {
+    "id": 72,
+    "name": "Ultimus Pool",
+    "addresses": [
+      "1EMVSMe1VJUuqv7D7SFzctnVXk4KdjXATi",
+      "3C9sAKXrBVpJVe3b738yik4LPHpPmceBgd"
+    ],
+    "tags": [
+      "/ultimus/"
+    ],
+    "link": "https://www.ultimuspool.com"
+  },
+  {
+    "id": 73,
+    "name": "BTCServ",
+    "addresses": [],
+    "tags": [
+      "btcserv"
+    ],
+    "link": "https://btcserv.net"
+  },
+  {
+    "id": 74,
+    "name": "Pega Pool",
+    "addresses": [
+      "1BGFwRzjCfRR7EvRHnzfHyFjGR8XiBDFKa"
+    ],
+    "tags": [
+      "/pegapool/"
+    ],
+    "link": "https://www.pega-pool.com"
+  },
+  {
+    "id": 75,
+    "name": "CKPool",
+    "addresses": [
+      "1ApE99VM5RJzMRRtwd2JMgmkGabtJqoMEz",
+      "1EowSPumj9D9AMTpE64Jr7vT3PJDNopVcz",
+      "1KGbsDDAgJN2HDNBjmMHp9828qATo5B9c9",
+      "3P8sR3K8wAk3bom7tqpr5VrzCz9TVYNTQd"
+    ],
+    "tags": [
+      "/ckpool.org/",
+      "ckpool"
+    ],
+    "link": "https://ckpool.org"
+  },
+  {
+    "id": 76,
+    "name": "Terra Pool",
+    "addresses": [
+      "32P5KVSbZYAkVmSHxDd2oBXaSk372rbV7L",
+      "3Qqp7LwxmSjPwRaKkDToysJsM3xA4ThqFk"
+    ],
+    "tags": [
+      "terrapool.io"
+    ],
+    "link": "https://terrapool.io"
+  },
+  {
+    "id": 77,
+    "name": "Mt Red",
+    "addresses": [],
+    "tags": [
+      "/mtred/"
+    ],
+    "link": "https://mtred.com"
+  },
+  {
+    "id": 78,
+    "name": "MiningCity",
+    "addresses": [
+      "11wC5KcbgrWRBb43cwADdVrxgyF8mndVC"
+    ],
+    "tags": [
+      "MiningCity"
+    ],
+    "link": "https://www.miningcity.com"
+  },
+  {
+    "id": 79,
+    "name": "Bitparking",
+    "addresses": [],
+    "tags": [
+      "bitparking"
+    ],
+    "link": "https://mmpool.bitparking.com"
+  },
+  {
+    "id": 80,
+    "name": "KnCMiner",
+    "addresses": [],
+    "tags": [
+      "KnCMiner"
+    ],
+    "link": "https://portal.kncminer.com/pool"
+  },
+  {
+    "id": 81,
+    "name": "Telco 214",
+    "addresses": [
+      "13Sd8Y7nUao3z4bJFkZvCRXpFqHvLy49YY",
+      "14M1pQ5KKeqmDrmqKyZEnaxAGJfBPrfWvQ",
+      "18ikmzPqk721ZNvWhDos1UL4H29w352Kj5",
+      "1AsEJU4ht5wR7BzV6xsNQpwi5qRx4qH1ac",
+      "1BUhwvF9oo3qkaSjjPpWrUzQxXNjkHdMZF",
+      "1CNq2FAw6S5JfBiDkjkYJUVNQwjoeY4Zfi",
+      "1DXRoTT67mCbhdHHL1it4J1xsSZHHnFxYR",
+      "1GaKSh2t396nfSg5Ku2J3Yn1vfVsXrGuH5",
+      "1LXWA3EEEwPixQcyFWXKX2hWHpkDoLknZW",
+      "1MoYfV4U61wqTPTHCyedzFmvf2o3uys2Ua",
+      "1P4B6rx1js8TaEDXvZvtrkiEb9XrJgMQ19"
+    ],
+    "tags": [],
+    "link": "https://www.telco214.com"
+  },
+  {
+    "id": 82,
+    "name": "A-XBT",
+    "addresses": [
+      "1MFsp2txCPwMMBJjNNeKaduGGs8Wi1Ce7X"
+    ],
+    "tags": [
+      "/A-XBT/"
+    ],
+    "link": "https://www.a-xbt.com"
+  },
+  {
+    "id": 83,
+    "name": "EclipseMC",
+    "addresses": [
+      "15xiShqUqerfjFdyfgBH1K7Gwp6cbYmsTW",
+      "18M9o2mXNjNR96yKe7eyY6pfP6Nx4Nso3d"
+    ],
+    "tags": [
+      "EMC"
+    ],
+    "link": "https://eclipsemc.com"
+  },
+  {
+    "id": 84,
+    "name": "Titan",
+    "addresses": [
+      "14hLEtxozmmih6Gg5xrGZLfx51bEMj21NW"
+    ],
+    "tags": [
+      "Titan.io"
+    ],
+    "link": "https://titan.io"
+  },
+  {
+    "id": 85,
+    "name": "BitMinter",
+    "addresses": [
+      "19PkHafEN18mquJ9ChwZt5YEFoCdPP5vYB"
+    ],
+    "tags": [
+      "BitMinter"
+    ],
+    "link": "https://bitminter.com"
+  },
+  {
+    "id": 86,
+    "name": "GoGreenLight",
+    "addresses": [
+      "18EPLvrs2UE11kWBB3ABS7Crwj5tTBYPoa"
+    ],
+    "tags": [],
+    "link": "https://www.gogreenlight.se"
+  },
+  {
+    "id": 87,
+    "name": "haominer",
+    "addresses": [],
+    "tags": [
+      "/haominer/"
+    ],
+    "link": "https://haominer.com"
+  },
+  {
+    "id": 88,
+    "name": "Foundry USA",
+    "addresses": [
+      "12KKDt4Mj7N5UAkQMN7LtPZMayenXHa8KL",
+      "1FFxkVijzvUPUeHgkFjBk2Qw8j3wQY2cDw"
+    ],
+    "tags": [
+      "/2cDw/",
+      "Foundry USA Pool"
+    ],
+    "link": "https://foundrydigital.com"
+  },
+  {
+    "id": 89,
+    "name": "Tiger Pool",
+    "addresses": [
+      "1LsFmhnne74EmU4q4aobfxfrWY4wfMVd8w"
+    ],
+    "tags": [
+      "tiger",
+      "tigerpool.net"
+    ],
+    "link": ""
+  },
+  {
+    "id": 90,
+    "name": "ConnectBTC",
+    "addresses": [
+      "1KPQkehgYAqwiC6UCcbojM3mbGjURrQJF2"
+    ],
+    "tags": [
+      "/ConnectBTC - Home for Miners/"
+    ],
+    "link": "https://www.connectbtc.com"
+  },
+  {
+    "id": 91,
+    "name": "Bitfarms",
+    "addresses": [
+      "3GvEGtnvgeBJ3p3EpdZhvUkxY4pDARkbjd"
+    ],
+    "tags": [
+      "BITFARMS"
+    ],
+    "link": "https://www.bitfarms.io"
+  },
+  {
+    "id": 92,
+    "name": "Eobot",
+    "addresses": [
+      "16GsNC3q6KgVXkUX7j7aPxSUdHrt1sN2yN",
+      "1MPxhNkSzeTNTHSZAibMaS8HS1esmUL1ne"
+    ],
+    "tags": [],
+    "link": "https://eobot.com"
+  },
+  {
+    "id": 93,
+    "name": "Hummerpool",
+    "addresses": [],
+    "tags": [
+      "HummerPool",
+      "Hummerpool"
+    ],
+    "link": "https://www.hummerpool.com"
+  },
+  {
+    "id": 94,
+    "name": "HAOZHUZHU",
+    "addresses": [
+      "19qa95rTbDziNCS9EexUbh2hVY4viUU9tt"
+    ],
+    "tags": [
+      "/haozhuzhu/"
+    ],
+    "link": "https://haozhuzhu.com"
+  },
+  {
+    "id": 95,
+    "name": "BitcoinIndia",
+    "addresses": [
+      "1AZ6BkCo4zgTuuLpRStJH8iNsehXTMp456"
+    ],
+    "tags": [
+      "/Bitcoin-India/"
+    ],
+    "link": "https://bitcoin-india.org"
+  },
+  {
+    "id": 96,
+    "name": "Lubian.com",
+    "addresses": [
+      "34Jpa4Eu3ApoPVUKNTN2WeuXVVq1jzxgPi"
+    ],
+    "tags": [
+      "/Buffett/",
+      "/lubian.com/"
+    ],
+    "link": "https://www.lubian.com"
+  },
+  {
+    "id": 97,
+    "name": "7pool",
+    "addresses": [
+      "1JLc3JxvpdL1g5zoX8sKLP4BkJQiwnJftU"
+    ],
+    "tags": [
+      "/$Mined by 7pool.com/"
+    ],
+    "link": "https://7pool.com"
+  },
+  {
+    "id": 98,
+    "name": "TMSPool",
+    "addresses": [],
+    "tags": [
+      "/TMSPOOL/"
+    ],
+    "link": "https://btc.tmspool.top"
+  },
+  {
+    "id": 99,
+    "name": "okpool.top",
+    "addresses": [],
+    "tags": [
+      "/www.okpool.top/"
+    ],
+    "link": "https://www.okpool.top"
+  },
+  {
+    "id": 100,
+    "name": "BWPool",
+    "addresses": [
+      "1JLRXD8rjRgQtTS9MvfQALfHgGWau9L9ky"
+    ],
+    "tags": [
+      "BW Pool",
+      "BWPool"
+    ],
+    "link": "https://bwpool.net"
+  },
+  {
+    "id": 101,
+    "name": "BTCPool (unidentified)",
+    "addresses": [
+      "1Ca1KNQQo8akbrwTjjXuk8aikvC2pwodU2"
+    ],
+    "tags": [
+      "BTCPool"
+    ],
+    "link": "https://github.com/0xB10C/known-mining-pools/issues/28"
+  },
+  {
+    "id": 102,
+    "name": "digitalX Mintsy",
+    "addresses": [
+      "1NY15MK947MLzmPUa2gL7UgyR8prLh2xfu"
+    ],
+    "tags": [],
+    "link": "https://www.mintsy.co"
+  },
+  {
+    "id": 103,
+    "name": "NiceHash",
+    "addresses": [],
+    "tags": [
+      "/NiceHashSolo"
+    ],
+    "link": "https://solo.nicehash.com"
+  },
+  {
+    "id": 104,
+    "name": "BitcoinRussia",
+    "addresses": [
+      "14R2r9FkyDmyxGB9xUVwVLdgsX9YfdVamk",
+      "165GCEAx81wce33FWEnPCRhdjcXCrBJdKn"
+    ],
+    "tags": [
+      "/Bitcoin-Russia.ru/"
+    ],
+    "link": "https://bitcoin-russia.ru"
+  },
+  {
+    "id": 105,
+    "name": "50BTC",
+    "addresses": [],
+    "tags": [
+      "50BTC"
+    ],
+    "link": "https://www.50btc.com"
+  },
+  {
+    "id": 106,
+    "name": "SBI Crypto",
+    "addresses": [],
+    "tags": [
+      "/SBICrypto.com Pool/",
+      "SBI Crypto",
+      "SBICrypto"
+    ],
+    "link": "https://sbicrypto.com"
+  },
+  {
+    "id": 107,
+    "name": "BTCC",
+    "addresses": [
+      "152f1muMCNa7goXYhYAQC61hxEgGacmncB"
+    ],
+    "tags": [
+      "/BTCC/",
+      "BTCChina Pool",
+      "BTCChina.com",
+      "btcchina.com"
+    ],
+    "link": "https://pool.btcc.com"
+  },
+  {
+    "id": 108,
+    "name": "MaxBTC",
+    "addresses": [],
+    "tags": [
+      "MaxBTC"
+    ],
+    "link": "https://maxbtc.com"
+  },
+  {
+    "id": 109,
+    "name": "BTPOOL",
+    "addresses": [],
+    "tags": [
+      "/BTPOOL/"
+    ],
+    "link": ""
+  },
+  {
+    "id": 110,
+    "name": "ViaBTC",
+    "addresses": [],
+    "tags": [
+      "/ViaBTC/",
+      "viabtc.com deploy"
+    ],
+    "link": "https://viabtc.com"
+  },
+  {
+    "id": 111,
+    "name": "Poolin",
+    "addresses": [
+      "14sA8jqYQgMRQV9zUtGFvpeMEw7YDn77SK",
+      "17tUZLvy3X2557JGhceXRiij2TNYuhRr4r",
+      "1E8CZo2S3CqWg1VZSJNFCTbtT8hZPuQ2kB",
+      "1GNgwA8JfG7Kc8akJ8opdNWJUihqUztfPe",
+      "1M1Xw2rczxkF3p3wiNHaTmxvbpZZ7M6vaa",
+      "1PtT8a79X2CbFSqwX2nCZjrvqaGRgfLxbz",
+      "33TbzA5AMiTKUCmeVEdsnTj3GiVXuavCAH",
+      "35qGBQsRQb8CSUzcSWktMykeA6zm5iCEJJ",
+      "36n452uGq1x4mK7bfyZR8wgE47AnBb2pzi",
+      "3A2dwyVPbZc41vvmJVYxYsrkvNKnz2B4wN",
+      "3DXfeMBimuvN3TWnQXDhr47P8M8yxMy9Pd",
+      "3JQSigWTCHyBLRD979JWgEtWP5YiiFwcQB",
+      "3KJrsjfg1dD6CrsTeHdHVH3KqMpvL2XWQn"
+    ],
+    "tags": [
+      "/poolin",
+      "/poolin.com"
+    ],
+    "link": "https://www.poolin.com"
+  },
+  {
+    "id": 112,
+    "name": "CN/TT",
+    "addresses": [
+      "3QLeXx1J9Tp3TBnQyHrhVxne9KqkAS9JSR"
+    ],
+    "tags": [],
+    "link": ""
+  },
+  {
+    "id": 113,
+    "name": "TBDice",
+    "addresses": [],
+    "tags": [
+      "TBDice"
+    ],
+    "link": "https://tbdice.org"
+  },
+  {
+    "id": 114,
+    "name": "CanoePool",
+    "addresses": [
+      "1GP8eWArgpwRum76saJS4cZKCHWJHs9PQo"
+    ],
+    "tags": [
+      "/CANOE/",
+      "/canoepool/"
+    ],
+    "link": "https://canoepool.com"
+  },
+  {
+    "id": 115,
+    "name": "HHTT",
+    "addresses": [],
+    "tags": [
+      "HHTT"
+    ],
+    "link": "https://hhtt.1209k.com"
+  },
+  {
+    "id": 116,
+    "name": "21 Inc.",
+    "addresses": [
+      "15rQXUSBQRubShPpiJfDLxmwS8ze2RUm4z",
+      "1CdJi2xRTXJF6CEJqNHYyQDNEcM3X7fUhD",
+      "1GC6HxDvnchDdb5cGkFXsJMZBFRsKAXfwi"
+    ],
+    "tags": [
+      "/pool34/"
+    ],
+    "link": "https://21.co"
+  },
+  {
+    "id": 117,
+    "name": "BlockFills",
+    "addresses": [
+      "1PzVut5X6Nx7Mv4JHHKPtVM9Jr9LJ4Rbry"
+    ],
+    "tags": [
+      "BlockfillsPool"
+    ],
+    "link": "https://www.blockfills.com/mining"
+  },
+  {
+    "id": 118,
+    "name": "KanoPool",
+    "addresses": [],
+    "tags": [
+      "Kano"
+    ],
+    "link": "https://kano.is"
+  },
+  {
+    "id": 119,
+    "name": "Braiins Pool",
+    "addresses": [
+      "1AqTMY7kmHZxBuLUR5wJjPFUvqGs23sesr",
+      "1CK6KHY6MHgYvmRQ4PAafKYDrg1ejbH1cE"
+    ],
+    "tags": [
+      "/slush/"
+    ],
+    "link": "https://braiins.com/"
+  },
+  {
+    "id": 120,
+    "name": "58COIN",
+    "addresses": [
+      "199EDJoCpqV672qESEkfFgEqNT1iR2gj3t"
+    ],
+    "tags": [
+      "/58coin.com/"
+    ],
+    "link": "https://www.58coin.com"
+  },
+  {
+    "id": 121,
+    "name": "HotPool",
+    "addresses": [
+      "17judvK4AC2M6KhaBbAEGw8CTKc9Pg8wup"
+    ],
+    "tags": [
+      "/HotPool/"
+    ],
+    "link": "https://hotpool.co"
+  },
+  {
+    "id": 122,
+    "name": "Bitalo",
+    "addresses": [],
+    "tags": [
+      "Bitalo"
+    ],
+    "link": "https://bitalo.com/mining"
+  },
+  {
+    "id": 123,
+    "name": "Binance Pool",
+    "addresses": [
+      "122pN8zvqTxJaA8fRY1PDBu4QYodqE5m2X",
+      "16moWjUJVRnDQKqhoCdcszfJg9wzBdoTHw",
+      "1DSh7vX6ed2cgTeKPwufV5i4hSi4pp373h",
+      "1JvXhnHCi6XqcanvrZJ5s2Qiv4tsmm2UMy",
+      "3L8Ck6bm3sve1vJGKo6Ht2k167YKSKi8TZ",
+      "bc1qx9t2l3pyny2spqpqlye8svce70nppwtaxwdrp4"
+    ],
+    "tags": [
+      "/Binance/",
+      "binance",
+      "binance.com/",
+      "binance/"
+    ],
+    "link": "https://pool.binance.com"
+  },
+  {
+    "id": 124,
+    "name": "WAYI.CN",
+    "addresses": [],
+    "tags": [
+      "/E2M & BTC.TOP/",
+      "/E2M/"
+    ],
+    "link": "https://www.easy2mine.com"
+  },
+  {
+    "id": 125,
+    "name": "BCMonster",
+    "addresses": [
+      "1E18BNyobcoiejcDYAz5SjbrzifNDEpM88"
+    ],
+    "tags": [
+      "/BCMonster/"
+    ],
+    "link": "https://www.bcmonster.com"
+  },
+  {
+    "id": 126,
+    "name": "Huobi Pool",
+    "addresses": [
+      "18Zcyxqna6h7Z7bRjhKvGpr8HSfieQWXqj",
+      "1EepjXgvWUoRyNvuLSAxjiqZ1QqKGDANLW",
+      "1MvYASoHjqynMaMnP7SBmenyEWiLsTqoU6",
+      "3HuobiNg2wHjdPU2mQczL9on8WF7hZmaGd"
+    ],
+    "tags": [
+      "/HuoBi/",
+      "/Huobi/"
+    ],
+    "link": "https://www.hpt.com"
+  },
+  {
+    "id": 127,
+    "name": "AAO Pool",
+    "addresses": [
+      "12QVFmJH2b4455YUHkMpEnWLeRY3eJ4Jb5"
+    ],
+    "tags": [
+      "/AAOPOOL/"
+    ],
+    "link": "https://btc.tmspool.top"
+  },
+  {
+    "id": 128,
+    "name": "Bixin",
+    "addresses": [
+      "13hQVEstgo4iPQZv9C7VELnLWF7UWtF4Q3",
+      "1KsFhYKLs8qb1GHqrPxHoywNQpet2CtP9t"
+    ],
+    "tags": [
+      "/Bixin/",
+      "/HaoBTC/",
+      "HAOBTC"
+    ],
+    "link": "https://haopool.com"
+  },
+  {
+    "id": 129,
+    "name": "CoinLab",
+    "addresses": [],
+    "tags": [
+      "CoinLab"
+    ],
+    "link": "https://coinlab.com"
+  },
+  {
+    "id": 130,
+    "name": "GBMiners",
+    "addresses": [],
+    "tags": [
+      "/mined by gbminers/"
+    ],
+    "link": "https://gbminers.com"
+  },
+  {
+    "id": 131,
+    "name": "UNOMP",
+    "addresses": [
+      "1BRY8AD7vSNUEE75NjzfgiG18mWjGQSRuJ"
+    ],
+    "tags": [],
+    "link": "https://199.115.116.7:8925"
+  },
+  {
+    "id": 132,
+    "name": "ASICMiner",
+    "addresses": [],
+    "tags": [
+      "ASICMiner"
+    ],
+    "link": "https://www.asicminer.co"
+  },
+  {
+    "id": 133,
+    "name": "Bitsolo",
+    "addresses": [
+      "18zRehBcA2YkYvsC7dfQiFJNyjmWvXsvon"
+    ],
+    "tags": [
+      "Bitsolo Pool"
+    ],
+    "link": "https://bitsolo.net"
+  },
+  {
+    "id": 134,
+    "name": "digitalBTC",
+    "addresses": [
+      "1MimPd6LrPKGftPRHWdfk8S3KYBfN4ELnD"
+    ],
+    "tags": [
+      "/agentD/"
+    ],
+    "link": "https://digitalbtc.com"
+  },
+  {
+    "id": 135,
+    "name": "CloudHashing",
+    "addresses": [
+      "1ALA5v7h49QT7WYLcRsxcXqXUqEqaWmkvw"
+    ],
+    "tags": [],
+    "link": "https://cloudhashing.com"
+  },
+  {
+    "id": 136,
+    "name": "Rawpool",
+    "addresses": [
+      "35y82tEPDa2wm6tzkEacMG8GPPW7zbMj83",
+      "3CLigLYNkrtoNgNcUwTaKoUSHCwr9W851W",
+      "3QYvfQoG9Gs9Vfvbpw6947muSqhoGagvF6"
+    ],
+    "tags": [
+      "/Rawpool.com/"
+    ],
+    "link": "https://www.rawpool.com"
+  },
+  {
+    "id": 137,
+    "name": "EXX&BW",
+    "addresses": [],
+    "tags": [
+      "xbtc.exx.com&bw.com"
+    ],
+    "link": "https://xbtc.exx.com"
+  },
+  {
+    "id": 138,
+    "name": "BTCMP",
+    "addresses": [
+      "1jKSjMLnDNup6NPgCjveeP9tUn4YpT94Y"
+    ],
+    "tags": [],
+    "link": "https://www.btcmp.com"
+  },
+  {
+    "id": 139,
+    "name": "bcpool.io",
+    "addresses": [],
+    "tags": [
+      "bcpool.io"
+    ],
+    "link": "https://bcpool.io"
+  },
+  {
+    "id": 140,
+    "name": "MARA Pool",
+    "addresses": [
+      "15MdAHnkxt9TMC2Rj595hsg8Hnv693pPBB",
+      "1A32KFEX7JNPmU1PVjrtiXRrTQcesT3Nf1",
+      "3D72db1KMCnj7FL7MBsmxTw81z2bVu4UN5",
+      "3LC8dDKyBsrWPfzhXyt7aAyjXxGYkfDdHu"
+    ],
+    "tags": [
+      "MARA Pool"
+    ],
+    "link": "https://marathondh.com"
+  }
+]

--- a/pools-v2.json
+++ b/pools-v2.json
@@ -28,7 +28,8 @@
     "tags": [
       "/EMCD/",
       "/one_more_mcd/",
-      "get___emcd"
+      "get___emcd",
+      "emcd"
     ],
     "link": "https://pool.emcd.io"
   },

--- a/pools-v2.json
+++ b/pools-v2.json
@@ -889,7 +889,8 @@
       "18M9o2mXNjNR96yKe7eyY6pfP6Nx4Nso3d"
     ],
     "tags": [
-      "EMC"
+      "EMC: ",
+      "EMC "
     ],
     "link": "https://eclipsemc.com"
   },


### PR DESCRIPTION
Depends on https://github.com/mempool/mining-pools/pull/29

### Currently

We're missing `emcd` tag. So they end up in the unknown blocks.

<img width="1403" alt="image" src="https://user-images.githubusercontent.com/9780671/218248866-83a5386e-dd55-4965-9f1a-2d2caa983004.png">

### With this update

Unknown blocks
<img width="1371" alt="image" src="https://user-images.githubusercontent.com/9780671/218249188-c0847649-a9d9-4006-b786-91f3a8be1e59.png">

EMCDPool
<img width="1395" alt="image" src="https://user-images.githubusercontent.com/9780671/218249256-e2e9cb5d-d1f7-407f-856f-f1f643626027.png">
