### PR TITLE
Add /F2Pool/ tag

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -385,6 +385,7 @@
     ],
     "tags": [
       "七彩神仙鱼",
+      "/F2Pool/",
       "🐟"
     ],
     "link": "https://www.f2pool.com"


### PR DESCRIPTION
Adding `/F2Pool/` tag so we don't just match by address.