### PR TITLE
Foundry USA -> Foundry USA Pool

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1226,7 +1226,7 @@
   },
   {
     "id": 111,
-    "name": "Foundry USA",
+    "name": "Foundry USA Pool",
     "addresses": [
       "12KKDt4Mj7N5UAkQMN7LtPZMayenXHa8KL",
       "1FFxkVijzvUPUeHgkFjBk2Qw8j3wQY2cDw",


### PR DESCRIPTION
```
Jul 28 14:00:17 [27178] WARN: [Mining] pools-v2.json is outdated, fetching latest from https://raw.githubusercontent.com/mempool/mining-pools/nymkappa/rename-foundry/pools-v2.json over clearnet
Jul 28 14:00:17 [27178] WARN: Renaming Foundry USA mining pool to Foundry USA Pool. Slug has been updated. Maybe you want to make a redirection from 'https://mempool.space/mining/pool/foundryusa' to 'https://mempool.space/mining/pool/foundryusapool
```

Still looks good, only the mobile mining dashboard text is a bit funny looking but we can manually wrap it if needed (see last screenshot):

<img width="565" alt="Screenshot 2023-07-28 at 14 14 21" src="https://github.com/mempool/mining-pools/assets/9780671/c079b84b-fef9-4401-a51a-35a84bde31dc">
<img width="2556" alt="Screenshot 2023-07-28 at 14 14 15" src="https://github.com/mempool/mining-pools/assets/9780671/2e23a998-4486-46b3-8a16-46b05a65e82e">
<img width="1217" alt="Screenshot 2023-07-28 at 14 14 45" src="https://github.com/mempool/mining-pools/assets/9780671/790ea33d-bc43-483f-8ba8-c7b02d99a6a6">
<img width="2560" alt="Screenshot 2023-07-28 at 14 14 29" src="https://github.com/mempool/mining-pools/assets/9780671/00a5db16-565c-4094-b816-b54ebeb9e060">
<img width="563" alt="Screenshot 2023-07-28 at 14 23 03" src="https://github.com/mempool/mining-pools/assets/9780671/e782fc39-9f87-4424-8e53-de741aab32f4">

<img width="354" alt="Screenshot 2023-07-28 at 14 23 12" src="https://github.com/mempool/mining-pools/assets/9780671/e4002ddb-46d7-4330-931d-2eb55c19471a">
