### PR TITLE
Classification of all addresses related to mining pools

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,93 @@
+## `pool_addresses.csv`: a classification of all addresses related to known mining pools
+
+The scripts in this directory are used to generate the file `pool_addresses.csv` that contains all the addresses related to known mining pools referenced in `pools-v2.json`.
+
+`pool_addresses.csv` contains every pair `address` - `pool_id` where `address` is a bitcoin address related to one or more mining pools and `pool_id` is the id of the pool. Note that since an address can be related to multiple known mining pools, the table can contain multiple rows for the same address.
+
+Each row looks like this:
+
+| address  | pool_id |  pool_value  |
+| -------- | ------- | ------------ |
+| 39PV... | 94 | 391072421935 |
+| 3KfRw... |    6    | 147319130014 |
+
+Where:
+- `address` is an address that received a coinbase transaction from a known mining pool
+- `pool_id` is the id of the related known pool
+- `pool_value` is the total number of sats mined by the address with `pool_id`
+
+This table is used to access mining pools associated with addresses in a way that scales well when the number of known addresses grows.
+
+The data generation process is explained below. It could eliminate the need for manual address additions to `pools-v2.json` and includes all known addresses (no omission).
+
+## How to generate `pools_addresses.csv`:
+
+### Prerequisites:
+- bitcoin node with following `bitcoin.conf`:
+```
+rpcuser=mempool
+rpcpassword=replace_me
+rpcport=8332 # Listening on localhost
+```
+
+- mariadb or similar database server with a user `mempool`:
+```
+MariaDB [(none)]> drop database coinbase;
+Query OK, 0 rows affected (0.00 sec)
+
+MariaDB [(none)]> create database coinbase;
+Query OK, 1 row affected (0.00 sec)
+
+MariaDB [(none)]> grant all privileges on coinbase.* to 'mempool'@'%' identified by 'mempool';
+Query OK, 0 rows affected (0.00 sec)
+```
+
+### Steps
+
+1. Clone the repository and go to the `scripts` directory
+
+2. Replace the rpc credentials in `coinbase_data.py` with your own
+
+3. Run `python3 coinbase_data.py`
+
+This should take few hours to compute. It populates the table `coinbase_data` from block 1 to current height with the following columns:
+
+| Height  | Coinbase Signature | Output Addresses     | Output Values | Pool Id |
+| ------- | ------------------ | -------------------- | ------------- | ------- |
+| 123456  | 04ffff001d0280...  | ["1A1z...","38Xn..."] | [1234, 5678]  | 100     |
+
+
+Where:
+- `Height` is the block height
+- `Coinbase Signature` is the signature of the coinbase transaction
+- `Output Addresses` is the list of all the output addresses of the coinbase transaction
+- `Output Values` is the list of all the corresponding output values (in sats) of the coinbase transaction
+- `Pool Id` is the id of the pool that mined the block according to `pools-v2.json` (0 if unknown)
+
+
+The table `coinbase_data` contains all the coinbase transactions data up to current block height (size is >300MB)
+
+4. Run `python3 mining_addresses.py`
+
+This uses the `coinbase_data` table to populate the tables `mining_addresses` and `pool_addresses`. The table `mining_addresses` simply lists all the addresses that ever received one or more coinbase transaction(s) and acts as foreign key for `pool_addresses`.
+
+The table we are interested in is `pool_addresses` that only contains addresses related to known mining pools. Its structure is described [here](#pool_addressescsv-a-classification-of-all-addresses-related-to-known-mining-pools).
+
+5. Export `pool_addresses` to csv
+
+```
+rm /path/to/pool_addresses.csv
+mariadb> SELECT * FROM pool_addresses INTO OUTFILE '/path/to/pool_addresses.csv' FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n';
+```
+
+----------------------------------------------
+Last update of `pool_addresses.csv`:
+
+```
+MariaDB [coinbase]> SELECT MAX(Last_Block_Update) FROM mining_addresses;
++------------------------+
+| MAX(Last_Block_Update) |
++------------------------+
+|                 820165 |
++------------------------+
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,8 +1,8 @@
-## `pool_addresses.csv`: a classification of all addresses related to known mining pools
+## `pools_addresses.csv`: a classification of all addresses related to known mining pools
 
-The scripts in this directory are used to generate the file `pool_addresses.csv` that contains all the addresses related to known mining pools referenced in `pools-v2.json`.
+The scripts in this directory are used to generate the file `pools_addresses.csv` that contains all the addresses related to known mining pools referenced in `pools-v2.json`.
 
-`pool_addresses.csv` contains every pair `address` - `pool_id` where `address` is a bitcoin address related to one or more mining pools and `pool_id` is the id of the pool. Note that since an address can be related to multiple known mining pools, the table can contain multiple rows for the same address.
+`pools_addresses.csv` contains every pair `address` - `pool_id` where `address` is a bitcoin address related to one or more mining pools and `pool_id` is the id of the pool. Note that since an address can be related to multiple known mining pools, the table can contain multiple rows for the same address.
 
 Each row looks like this:
 
@@ -69,19 +69,19 @@ The table `coinbase_data` contains all the coinbase transactions data up to curr
 
 4. Run `python3 mining_addresses.py`
 
-This uses the `coinbase_data` table to populate the tables `mining_addresses` and `pool_addresses`. The table `mining_addresses` simply lists all the addresses that ever received one or more coinbase transaction(s) and acts as foreign key for `pool_addresses`.
+This uses the `coinbase_data` table to populate the tables `mining_addresses` and `pools_addresses`. The table `mining_addresses` simply lists all the addresses that ever received one or more coinbase transaction(s) and acts as foreign key for `pools_addresses`.
 
-The table we are interested in is `pool_addresses` that only contains addresses related to known mining pools. Its structure is described [here](#pool_addressescsv-a-classification-of-all-addresses-related-to-known-mining-pools).
+The table we are interested in is `pools_addresses` that only contains addresses related to known mining pools. Its structure is described [here](#pool_addressescsv-a-classification-of-all-addresses-related-to-known-mining-pools).
 
-5. Export `pool_addresses` to csv
+5. Export `pools_addresses` to csv
 
 ```
-rm /path/to/pool_addresses.csv
-mariadb> SELECT * FROM pool_addresses INTO OUTFILE '/path/to/pool_addresses.csv' FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n';
+rm /path/to/pools_addresses.csv
+mariadb> SELECT * FROM pools_addresses INTO OUTFILE '/path/to/pools_addresses.csv' FIELDS TERMINATED BY ',' ENCLOSED BY '"' LINES TERMINATED BY '\n';
 ```
 
 ----------------------------------------------
-Last update of `pool_addresses.csv`:
+Last update of `pools_addresses.csv`:
 
 ```
 MariaDB [coinbase]> SELECT MAX(Last_Block_Update) FROM mining_addresses;

--- a/scripts/coinbase_data.py
+++ b/scripts/coinbase_data.py
@@ -1,0 +1,124 @@
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+import pymysql.cursors
+import json
+
+rpc_user = "mempool"
+rpc_password = "replace_me"
+rpc_port = 8332
+
+db_host = "localhost"
+db_user = "mempool"
+db_password = "mempool"
+db_name = "coinbase"
+
+default_starting_block = 1
+
+with open('../pools-v2.json') as f:
+    pools_data = json.load(f)
+
+def get_rpc_connection():
+    try:
+        rpc_connection = AuthServiceProxy(f"http://{rpc_user}:{rpc_password}@127.0.0.1:{rpc_port}/")
+        return rpc_connection
+    except JSONRPCException as e:
+        print(f"Error connecting to Bitcoin Core RPC: {e}")
+        return None
+
+def create_database_connection():
+    try:
+        connection = pymysql.connect(
+            host=db_host,
+            user=db_user,
+            password=db_password,
+            database=db_name,
+            cursorclass=pymysql.cursors.DictCursor
+        )
+        return connection
+    except pymysql.MySQLError as e:
+        print(f"Error connecting to MariaDB: {e}")
+        return None
+
+def hex_to_ascii(hex_str):
+    try:
+        return bytes.fromhex(hex_str).decode('ascii', errors='replace')
+    except UnicodeDecodeError as e:
+        print(f"Error decoding hex string: {e}")
+        return None
+
+rpc_connection = get_rpc_connection()
+if rpc_connection is None:
+    print("Can not connect to RPC: exiting")
+    sys.exit()
+
+db_connection = create_database_connection()
+if db_connection is None:
+    print("Can not connect to database: exiting")
+    sys.exit()
+
+try:
+    block_height = rpc_connection.getblockcount()
+
+    with db_connection.cursor() as cursor:
+        cursor.execute("""
+        CREATE TABLE IF NOT EXISTS coinbase_data (
+            Height INT PRIMARY KEY,
+            Coinbase_Signature TEXT,
+            Addresses TEXT,
+            Transaction_Values TEXT,
+            Pool_Id INT
+        )
+        """)
+        db_connection.commit()
+        cursor.execute("SELECT MAX(Height) FROM coinbase_data")
+        result = cursor.fetchone()
+        if result['MAX(Height)'] is not None:
+            default_starting_block = result['MAX(Height)'] + 1
+
+        for height in range(default_starting_block, block_height + 1):
+            block_hash = rpc_connection.getblockhash(height)
+            block = rpc_connection.getblock(block_hash)
+            coinbase_txid = block['tx'][0]
+            coinbase_transaction = rpc_connection.getrawtransaction(coinbase_txid, 1)
+
+            coinbase_signature = (coinbase_transaction['vin'][0]['coinbase'])
+            coinbase_script_ascii = hex_to_ascii(coinbase_signature)
+            pool_id = 0
+            for pool in pools_data:
+                for tag in pool['tags']:
+                    if tag in coinbase_script_ascii:
+                        pool_id = pool['id']
+                        break
+                if pool_id:
+                    break
+
+            addresses = []
+            values = []
+            for output in coinbase_transaction['vout']:
+                if output['value'] > 0:
+                    if output['scriptPubKey']['type'] == 'pubkey':
+                        addresses.append(output['scriptPubKey']['desc'].split('(')[1].split(')')[0])
+                        values.append(int(output['value'] * 100000000))
+                    elif 'address' in output['scriptPubKey']:
+                        addresses.append(output['scriptPubKey']['address'])
+                        values.append(int(output['value'] * 100000000))
+
+            insert_query = """
+            INSERT INTO coinbase_data (Height, Coinbase_Signature, Addresses, Transaction_Values, Pool_Id)
+            VALUES (%s, %s, %s, %s, %s)
+            """
+            cursor.execute(insert_query, (height, coinbase_signature, str(addresses), str(values), pool_id))
+
+            if height % 1000 == 0 or height == block_height or height == default_starting_block:
+                print(f"Block {height} / {block_height}")
+                print(f"Coinbase signature: {coinbase_signature}")
+                print(f"Addresses: {addresses}")
+                print(f"Output Values: {values}")
+                print(f"Pool ID: {pool_id}")
+                print("-" * 50)
+                db_connection.commit()
+        db_connection.commit()
+            
+except JSONRPCException as e:
+    print(f"Error while retrieving block information: {e}")
+finally:
+    db_connection.close()

--- a/scripts/mining_addresses.py
+++ b/scripts/mining_addresses.py
@@ -1,0 +1,103 @@
+import mysql.connector
+
+db_params = {
+    'host': 'localhost',
+    'user': 'mempool',
+    'password': 'mempool',
+    'database': 'coinbase'
+}
+
+connection = mysql.connector.connect(**db_params)
+cursor = connection.cursor()
+
+# Create the table that will contain all addresses that ever mined a coin
+create_addresses_table_query = """
+CREATE TABLE IF NOT EXISTS mining_addresses (
+    Address VARCHAR(140) PRIMARY KEY,
+    Last_Block_Update INT(11)
+)
+"""
+cursor.execute(create_addresses_table_query)
+connection.commit()
+
+# Create the table that will contain all addresses related to known mining pools
+create_pool_table_query = """
+CREATE TABLE IF NOT EXISTS pool_addresses (
+    Address VARCHAR(140),
+    Pool_Id INT,
+    Pool_Value BIGINT,
+    FOREIGN KEY (Address) REFERENCES mining_addresses(Address)
+)
+"""
+cursor.execute(create_pool_table_query)
+connection.commit()
+
+# Get needed data from the coinbase_data table 
+cursor.execute("SELECT MAX(Last_Block_Update) FROM mining_addresses")
+result = cursor.fetchone()
+if not result[0]:
+    select_query = "SELECT Height, Addresses, Transaction_Values, Pool_Id FROM coinbase_data"
+    cursor.execute(select_query)
+    coinbase_data = cursor.fetchall()
+else:
+    select_query = f"SELECT Height, Addresses, Transaction_Values, Pool_Id FROM coinbase_data WHERE Height > {result[0]}"
+    cursor.execute(select_query)
+    coinbase_data = cursor.fetchall()
+
+print("Completing mining addresses and pool addresses tables...")
+print(f"Number of blocks to process: {len(coinbase_data)}")
+
+for row in coinbase_data:
+    height = row[0]
+    addresses = row[1]
+    values = row[2]
+    pool_id = row[3]
+    for address, value in list(zip(eval(addresses), eval(values))):
+        # Insert or update the mining_addresses table
+        insert_address_query = f"""
+            INSERT INTO mining_addresses (Address, Last_Block_Update)
+            VALUES ('{address}', {height})
+            ON DUPLICATE KEY UPDATE Last_Block_Update = GREATEST(Last_Block_Update, {height})
+        """
+        cursor.execute(insert_address_query)
+
+        if pool_id == 0:
+            continue # Do not include addresses not related to known pools
+        # Check if the combination of Address and Pool_Id already exists
+        select_existing_query = f"""
+            SELECT Pool_Value
+            FROM pool_addresses
+            WHERE Address = '{address}' AND Pool_Id = {pool_id}
+        """
+        cursor.execute(select_existing_query)
+        existing_data = cursor.fetchone()
+
+        if existing_data:
+            # Update the existing row
+            update_query = f"""
+                UPDATE pool_addresses
+                SET Pool_Value = Pool_Value + {value}
+                WHERE Address = '{address}' AND Pool_Id = {pool_id}
+            """
+            cursor.execute(update_query)
+        else:
+            # Insert a new row
+            insert_pool_query = f"""
+                INSERT INTO pool_addresses (Address, Pool_Id, Pool_Value)
+                VALUES ('{address}', {pool_id}, {value})
+            """
+            cursor.execute(insert_pool_query)
+    
+    if height % 1000 == 0 or (result[0] and height == result[0] + 1) or height == 1:
+        print(f"Block {height} / {coinbase_data[-1][0]}")
+        connection.commit()
+
+connection.commit()
+cursor.execute("SELECT COUNT(*) FROM mining_addresses")
+print(f"Number of mining addresses: {cursor.fetchone()[0]}")
+print("Table mining_addresses completed.")
+cursor.execute("SELECT COUNT(*) FROM pool_addresses")
+print(f"Number of pool addresses: {cursor.fetchone()[0]}")
+print("Table pool_addresses completed.")
+
+connection.close()

--- a/scripts/mining_addresses.py
+++ b/scripts/mining_addresses.py
@@ -22,10 +22,11 @@ connection.commit()
 
 # Create the table that will contain all addresses related to known mining pools
 create_pool_table_query = """
-CREATE TABLE IF NOT EXISTS pool_addresses (
+CREATE TABLE IF NOT EXISTS pools_addresses (
     Address VARCHAR(140),
     Pool_Id INT,
     Pool_Value BIGINT,
+    INDEX idx_pool_id (Pool_Id),
     FOREIGN KEY (Address) REFERENCES mining_addresses(Address)
 )
 """
@@ -44,7 +45,7 @@ else:
     cursor.execute(select_query)
     coinbase_data = cursor.fetchall()
 
-print("Completing mining addresses and pool addresses tables...")
+print("Completing mining addresses and pools addresses tables...")
 print(f"Number of blocks to process: {len(coinbase_data)}")
 
 for row in coinbase_data:
@@ -66,7 +67,7 @@ for row in coinbase_data:
         # Check if the combination of Address and Pool_Id already exists
         select_existing_query = f"""
             SELECT Pool_Value
-            FROM pool_addresses
+            FROM pools_addresses
             WHERE Address = '{address}' AND Pool_Id = {pool_id}
         """
         cursor.execute(select_existing_query)
@@ -75,7 +76,7 @@ for row in coinbase_data:
         if existing_data:
             # Update the existing row
             update_query = f"""
-                UPDATE pool_addresses
+                UPDATE pools_addresses
                 SET Pool_Value = Pool_Value + {value}
                 WHERE Address = '{address}' AND Pool_Id = {pool_id}
             """
@@ -83,7 +84,7 @@ for row in coinbase_data:
         else:
             # Insert a new row
             insert_pool_query = f"""
-                INSERT INTO pool_addresses (Address, Pool_Id, Pool_Value)
+                INSERT INTO pools_addresses (Address, Pool_Id, Pool_Value)
                 VALUES ('{address}', {pool_id}, {value})
             """
             cursor.execute(insert_pool_query)
@@ -96,8 +97,8 @@ connection.commit()
 cursor.execute("SELECT COUNT(*) FROM mining_addresses")
 print(f"Number of mining addresses: {cursor.fetchone()[0]}")
 print("Table mining_addresses completed.")
-cursor.execute("SELECT COUNT(*) FROM pool_addresses")
-print(f"Number of pool addresses: {cursor.fetchone()[0]}")
-print("Table pool_addresses completed.")
+cursor.execute("SELECT COUNT(*) FROM pools_addresses")
+print(f"Number of pools addresses: {cursor.fetchone()[0]}")
+print("Table pools_addresses completed.")
 
 connection.close()


### PR DESCRIPTION
Following https://github.com/mempool/mining-pools/pull/43, this PR adds: 
- a file `pool_addresses.csv` that classifies all addresses linked to known mining pools. It contains every pair `address` - `pool_id`, where `address` is a bitcoin address related to `pool_id`. Note that since an address can be related to multiple known mining pools, the table can contain multiple rows for the same address
- a folder `scripts` that contains the scripts used to generate the data and a `README.md` explaining in detail the data generation process and the data structure used

This table will be used to implement the display of mining pool on the address page (https://github.com/mempool/mempool/issues/513) in a way that scales better than the first implementation (https://github.com/mempool/mempool/pull/4473) when the number of known addresses grows.

AFAIK, the process of adding new addresses related to pools to `pools-v2.json` is manual, resulting in many addresses being omitted. This PR could allow to solve this problem by implementing a routine to regularly update `pool_addresses.csv` using the provided scripts for example.