### PR TITLE
Remove slashes from F2Pool tag

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -386,7 +386,7 @@
     ],
     "tags": [
       "七彩神仙鱼",
-      "/F2Pool/",
+      "F2Pool",
       "🐟"
     ],
     "link": "https://www.f2pool.com"


### PR DESCRIPTION
This PR should fix https://github.com/mempool/mempool/issues/4636 by removing the starting and ending `/` from F2Pool tag, to correctly flag these blocks:

https://mempool.space/block/000000000000000000029232098531c5b33f5d541030fea5ad40495c47c98a8b
https://mempool.space/block/00000000000000000000f96b4efeb1c4a7857708e1eacab679f4b983897d0b73
