### PR TITLE
Add wk057 as pool

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1564,4 +1564,15 @@
     ],
     "link": ""
   }
+  {
+    "id": 144,
+    "name": "wk057",
+    "addresses": [
+      "1WizkidqARMLvjGUpfDQFRcEbnHpL55kK"
+    ],
+    "tags": [
+      "wizkid057's block"
+    ],
+    "link": ""
+  }
 ]

--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1597,9 +1597,9 @@
       "rijndael's toaster"
     ],
     "link": "https://twitter.com/rot13maxi"
-  }
+  },
   {
-    "id": 144,
+    "id": 147,
     "name": "wk057",
     "addresses": [
       "1WizkidqARMLvjGUpfDQFRcEbnHpL55kK"


### PR DESCRIPTION
Update to pools-vs.json to include "wk057" as pool for 8 blocks mined in 2012

tweet claiming blocks: https://twitter.com/wk057/status/1778192275694080088

on chain evidence: https://mempool.space/address/1WizkidqARMLvjGUpfDQFRcEbnHpL55kK