### PR TITLE
Add missing addresses field

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1612,6 +1612,7 @@
   {
     "id": 148,
     "name": "FutureBit Apollo Solo",
+    "addresses": [],
     "tags": [
       "Apollo",
       "/mined by a Solo FutureBit Apollo/"


### PR DESCRIPTION
Fixes https://github.com/mempool/mempool/issues/5079 by adding a missing `addresses` field to `FutureBit Apollo Solo` pool. 