### PR TITLE
Add link for whitepool

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1563,7 +1563,7 @@
     "tags": [
       "WhitePool"
     ],
-    "link": ""
+    "link": "https://whitebit.com/mining-pool"
   },
   {
     "id": 144,


### PR DESCRIPTION
Adds a website link for WhitePool (evidently run by WhiteBIT)
https://whitebit.com/mining-pool/