### PR TITLE
Add new MARA DH Coinbase Tag

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1279,7 +1279,8 @@
       "1A32KFEX7JNPmU1PVjrtiXRrTQcesT3Nf1"
     ],
     "tags": [
-      "MARA Pool"
+      "MARA Pool",
+      "MARA Made in USA"
     ],
     "link": "https://marapool.com"
   },


### PR DESCRIPTION
MARA will be updating their coinbase TAG on October. 8th 2024 to "MARA Made in USA". The current MARA Pool doesn't trigger the MARA label under blocks visualized on Mempool.