### PR TITLE
Fix luxor tags & add current address

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -41,11 +41,12 @@
     "name": "Luxor",
     "addresses": [
       "1MkCDCzHpBsYQivp8MxjY5AkTGG1f2baoe",
-      "39bitUyBcUu3y3hRTtYprKbTp712t4ZWqK"
+      "39bitUyBcUu3y3hRTtYprKbTp712t4ZWqK",
+      "32BfKjhByDSxx3BM5vUkQ3NQq9csZR6nt6"
     ],
     "tags": [
       "/LUXOR/",
-      "Powered by Luxor Tech"
+      "Luxor Tech"
     ],
     "link": "https://mining.luxor.tech"
   },


### PR DESCRIPTION
Luxor has changed their coinbase signature from "Powered by Luxor Tech" to "Mined by Luxor Tech", and we don't have their current payout address, causing recent blocks not to be identified.

This PR adds the new address and shortens the signature regex to just "Luxor Tech" to catch both forms.