### PR TITLE
Add RedRock Pool

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1784,5 +1784,14 @@
     "addresses": [],
     "tags": ["parasite"],
     "link": "https://parasite.space"
+  },
+  {
+    "id": 166,
+    "name": "RedRock Pool",
+    "addresses": [
+      "3554kSaWNnP3B49Xyybert7gmxq2YSnfnx"
+    ],
+    "tags": ["RedRock"],
+    "link": "https://redrock.pro/"
   }
 ]


### PR DESCRIPTION
Adds RedRock Pool: https://redrock.pro/

A new pool in the antpool & friends cluster, with [two](https://mempool.space/block/000000000000000000003a49842e7c3dbd9b86227beb45dca57cdbcb2c5f40b1) [blocks](https://mempool.space/block/0000000000000000000134e5473dacbc63dc16e1fad99184cddfe3164801846f) found since 2025-08-16.

I can't find a logo suitable for thumbnails, so I won't open a corresponding PR to the [mining-pool-logos](https://github.com/mempool/mining-pool-logos) repo just yet.

<img width="182" height="241" alt="Screenshot 2025-08-22 at 3 14 39 PM" src="https://github.com/user-attachments/assets/ede4c898-cc44-4c9a-97bc-5eef571b9548" />
