### PR TITLE
add UUID miner

### DIFF
--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1793,5 +1793,16 @@
     ],
     "tags": ["RedRock"],
     "link": "https://redrock.pro/"
+  },
+  {
+    "id": 167,
+    "name": "UUID Miner",
+    "addresses": [
+      "bc1q0a5zgnc08lhw23ddy7p34kkqwvkhhwn0u0nsnc",
+      "bc1q4k98v8y3sg8e7r3nfr0kmfufcf7mplyjq7utu6",
+      "bc1qvpstwkk28wpcrnuej0uf7af9u3lvns4epfdysh"
+    ],
+    "tags": [":\\/\\/[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}"],
+    "link": ""
   }
 ]

--- a/pools-v2.json
+++ b/pools-v2.json
@@ -1784,5 +1784,14 @@
     "addresses": [],
     "tags": ["parasite"],
     "link": "https://parasite.space"
+  },
+  {
+    "id": 166,
+    "name": "RedRock Pool",
+    "addresses": [
+      "3554kSaWNnP3B49Xyybert7gmxq2YSnfnx"
+    ],
+    "tags": ["RedRock"],
+    "link": "https://redrock.pro/"
   }
 ]


### PR DESCRIPTION
_(builds on #87)_

draft PR to add a regex-based match for an unknown but clearly identifiable miner/pool with rotating addresses and rotating hexadecimal v4 UUIDs in the coinbase in the format: `://ffffffff-ffff-ffff-ffff-ffffffffffff' (encoded in ASCII).

this entity makes up the overwhelming majority of "unknown" blocks in recent months (mining a total of 167 blocks so far), inflating the "unknown" share of blocks to ~1-2% at times.

although they've rotated through at least 3 different payout addresses so far, this is clearly a single entity from the consistency of the UUID scheme, the surrounding structure of the coinbase, and the fact that these payout addresses cluster around the same custodian.

I believe this will be the first use of a regex expression in the "tags" field rather than a simple string match, so we'll need to:
 - confirm this doesn't break anything (although the [README](https://github.com/mempool/mining-pools?tab=readme-ov-file#add-a-new-mining-pool-by-coinbase_tags) does document that "tags" are supposed to be regular expressions)
 - probably improve rendering/display of actual regex tags on the `mempool.space/mining/pool/...` page.
 
It would also be nice to identify who this actually is, but I think it would be informative to group their blocks under a pseudonym in the meantime.

<img width="800" height="414" alt="Screenshot 2025-08-22 at 10 31 16 PM" src="https://github.com/user-attachments/assets/7bea319c-1837-4d69-94fe-f01bb963edfb" />
<img width="802" height="621" alt="Screenshot 2025-08-22 at 10 49 22 PM" src="https://github.com/user-attachments/assets/6d355fe3-9ef8-4d69-bf1d-130de7c0398b" />

_(note: the consistent "h" near the start of the ASCII-decoded coinbase scriptsig isn't part of this miner's UUID pattern, but comes from the most significant byte of a 32-bit little-endian timestamp pushed immediately before the UUID data)_